### PR TITLE
Add 5.1.19 installer URLs

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -58,10 +58,12 @@ jobs:
             ["4.3.6"]="https://fw-download.ubnt.com/data/unifi-os-server/2f3a-linux-x64-4.3.6-be3b4ae0-6bcd-435d-b893-e93da668b9d0.6-x64"
             ["5.0.6"]="https://fw-download.ubnt.com/data/unifi-os-server/1856-linux-x64-5.0.6-33f4990f-6c68-4e72-9d9c-477496c22450.6-x64"
             ["5.1.15"]="https://fw-download.ubnt.com/data/unifi-os-server/24e0-linux-x64-5.1.15-926621de-c9d7-48cd-8921-a0ff3eebd3f4.15-x64"
+            ["5.1.19"]="https://fw-download.ubnt.com/data/unifi-os-server/b828-linux-x64-5.1.19-e38d0b0e-b462-403d-9861-f57f25772106.19-x64"
           )
           declare -A VERSION_URLS_ARM64=(
             ["5.0.6"]="https://fw-download.ubnt.com/data/unifi-os-server/df5b-linux-arm64-5.0.6-f35e944c-f4b6-4190-93a8-be61b96c58f4.6-arm64"
             ["5.1.15"]="https://fw-download.ubnt.com/data/unifi-os-server/adc4-linux-arm64-5.1.15-53ab1f2c-4cd5-4a5f-b750-d1aa35679b4f.15-arm64"
+            ["5.1.19"]="https://fw-download.ubnt.com/data/unifi-os-server/e027-linux-arm64-5.1.19-ebdd998e-306a-4880-af41-2bdc50e91e70.19-arm64"
           )
 
           URL_AMD64="${{ inputs.installer_url_amd64 || '' }}"


### PR DESCRIPTION
Add the linux-x64 and linux-arm64 installer URLs for UniFi OS Server 5.1.19 to the build workflow's version map.

Publishing the image is triggered by pushing a `v5.1.19` tag (done after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
